### PR TITLE
64-bit FMU simulation (#31)

### DIFF
--- a/PySimulator/Plugins/Simulator/FMUSimulator/FMUInterface.py
+++ b/PySimulator/Plugins/Simulator/FMUSimulator/FMUInterface.py
@@ -99,7 +99,7 @@ class fmiEventInfo(ctypes.Structure):
 
 ''' C-interface for system functions '''
 Logger = ctypes.CFUNCTYPE(None, fmiComponent, fmiString, fmiStatus, fmiString, fmiString)
-AllocateMemory = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_uint, ctypes.c_uint)
+AllocateMemory = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t)
 FreeMemory = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
 class _fmiCallbackFunctions(ctypes.Structure):
     _fields_ = [('logger', Logger), ('allocateMemory', AllocateMemory), ('freeMemory', FreeMemory)]
@@ -191,22 +191,23 @@ class FMUInterface:
             if self._loggingOn:
                 print(message)
             # self.log.append( (c, instanceName, status, category, message) )
-
         ''' mapping of memory management functions for FMU to operating system functions, depending on OS.
             For Linux it refers to the std-C library - this should always be present
         '''
         if platform.system() == 'Linux':
             c_lib = ctypes.cdll.LoadLibrary('libc.so.6')
-            self._fmiCallbackFunctions = _fmiCallbackFunctions(
-                                     logger=Logger(_Logger),
-                                     allocateMemory=AllocateMemory(c_lib.calloc),
-                                     freeMemory=FreeMemory(c_lib.free))
         elif platform.system() == 'Windows':
-            msvcrt_lib = ctypes.CDLL(find_library('c'))
-            self._fmiCallbackFunctions = _fmiCallbackFunctions(
-                                     logger=Logger(_Logger),
-                                     allocateMemory=AllocateMemory(msvcrt_lib.calloc),
-                                     freeMemory=FreeMemory(msvcrt_lib.free))
+            c_lib = ctypes.CDLL(find_library('c'))
+        else:
+            raise FMUError.FMUError('Unknown platform: %s\n' % platform.system())
+        c_lib.calloc.restype = ctypes.c_void_p
+        c_lib.calloc.argtypes = [ctypes.c_size_t,ctypes.c_size_t]
+        c_lib.free.restype = None
+        c_lib.free.argtypes = [ctypes.c_void_p]
+        self._fmiCallbackFunctions = _fmiCallbackFunctions(
+                                 logger=Logger(_Logger),
+                                 allocateMemory=AllocateMemory(c_lib.calloc),
+                                 freeMemory=FreeMemory(c_lib.free))
 
         ''' Load instance of library into memory '''
         try:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with PySimulator](http:www.modprod.liu.se/modprod2013-program/1.456422/modprod20
 
 ####Supported Platforms
 * Windows
-* Linux (OpenModelica and plotting works; FMU and other simulators do not work)
+* Linux (OpenModelica, FMU, and plotting works; other simulators do not work)
 * Other platforms have not been tested
 
 ####Installation


### PR DESCRIPTION
- Set the types of calloc and free in order to not truncate the pointer to a 32-bit value
