### PR TITLE
Fixes for failures in plugin importing

### DIFF
--- a/PySimulator/Plugins/SimulationResult/Csv/Csv.py
+++ b/PySimulator/Plugins/SimulationResult/Csv/Csv.py
@@ -24,7 +24,7 @@ along with PySimulator. If not, see www.gnu.org/licenses.
 '''
 
 import csv, numpy, collections
-from Plugins.SimulationResult import IntegrationResults
+from PySimulator.Plugins.SimulationResult import IntegrationResults
 
 
 fileExtension = 'csv'

--- a/PySimulator/Plugins/SimulationResult/DymolaMat/DymolaMat.py
+++ b/PySimulator/Plugins/SimulationResult/DymolaMat/DymolaMat.py
@@ -24,7 +24,7 @@ along with PySimulator. If not, see www.gnu.org/licenses.
 '''
 
 import os, numpy, scipy.io, string, collections
-from Plugins.SimulationResult import IntegrationResults
+from PySimulator.Plugins.SimulationResult import IntegrationResults
 
 # Exception classes
 class FileDoesNotExist     (Exception): pass

--- a/PySimulator/Plugins/SimulationResult/Mtsf/Mtsf.py
+++ b/PySimulator/Plugins/SimulationResult/Mtsf/Mtsf.py
@@ -29,7 +29,7 @@ import collections
 from operator import itemgetter
 import time
 import os
-from Plugins.SimulationResult import IntegrationResults
+from PySimulator.Plugins.SimulationResult import IntegrationResults
 
 
 import pyMtsf

--- a/PySimulator/Plugins/SimulationResult/Mtsf/MtsfFmi.py
+++ b/PySimulator/Plugins/SimulationResult/Mtsf/MtsfFmi.py
@@ -40,7 +40,7 @@ import os
 from operator import itemgetter
 
 import pyMtsf
-from Plugins.Simulator.FMUSimulator.FMIDescription import FMIDescription
+from PySimulator.Plugins.Simulator.FMUSimulator.FMIDescription import FMIDescription
 
 
 

--- a/PySimulator/Plugins/SimulationResult/ReconMeld/ReconMeld.py
+++ b/PySimulator/Plugins/SimulationResult/ReconMeld/ReconMeld.py
@@ -26,7 +26,7 @@ import os
 
 import numpy
 
-from Plugins.SimulationResult import IntegrationResults
+from PySimulator.Plugins.SimulationResult import IntegrationResults
 from recon.meld import MeldReader
 
 

--- a/PySimulator/Plugins/SimulationResult/SimulationXCsv/SimulationXCsv.py
+++ b/PySimulator/Plugins/SimulationResult/SimulationXCsv/SimulationXCsv.py
@@ -25,7 +25,7 @@ along with PySimulator. If not, see www.gnu.org/licenses.
 
 import csv, numpy, collections, math
 
-from Plugins.SimulationResult import IntegrationResults
+from PySimulator.Plugins.SimulationResult import IntegrationResults
 
 
 fileExtension = 'csvx'

--- a/PySimulator/Plugins/SimulationResult/SimulationXIsx/SimulationXIsx.py
+++ b/PySimulator/Plugins/SimulationResult/SimulationXIsx/SimulationXIsx.py
@@ -30,7 +30,7 @@ import string
 
 import numpy
 
-from Plugins.SimulationResult import IntegrationResults
+from PySimulator.Plugins.SimulationResult import IntegrationResults
 import PyResultX as isx
 from SimXUnitSI import unitSI
 

--- a/PySimulator/Plugins/Simulator/SimulatorBase.py
+++ b/PySimulator/Plugins/Simulator/SimulatorBase.py
@@ -37,7 +37,7 @@ of a loaded model and provides functions to simulate it, write and read results,
 import copy
 import os
 import string
-import Plugins.SimulationResult.IntegrationResults as IntegrationResults
+from PySimulator.Plugins.SimulationResult import IntegrationResults
 
 
 '''


### PR DESCRIPTION
After installing PySimulator from master, I got many errors from the plugins. The fix is to use the full module "path".